### PR TITLE
Support jsonpath from client-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,9 @@ spec:
 
     # Perform a field validation
     fields: 
-    - path: .status.phase=running
+    - path: .status.phase
+      values:
+      - running
 
     # This resource validation is required
     required: true

--- a/pkg/api/v1alpha1/resource.go
+++ b/pkg/api/v1alpha1/resource.go
@@ -36,18 +36,18 @@ func (c *ClusterResource) GetConfiguration() ValidationConfiguration {
 }
 
 type FieldSelector struct {
-	Path string `json:"path"`
+	Path   string   `json:"path"`
+	Values []string `json:"values"`
 }
 
-func (f *FieldSelector) JSONPath() string {
+func (f *FieldSelector) GetPath() string {
 	s := strings.Split(f.Path, "=")
 	return s[0]
 }
 
-func (f *FieldSelector) Values() []string {
-	s := strings.Split(f.Path, "=")
-	if len(s) > 1 {
-		return strings.Split(s[1], ",")
+func (f *FieldSelector) GetValues() []string {
+	if len(f.Values) > 0 {
+		return f.Values
 	}
 	return []string{"*"}
 }

--- a/pkg/client/helpers.go
+++ b/pkg/client/helpers.go
@@ -67,18 +67,6 @@ func getJsonPathValue(u unstructured.Unstructured, jsonPath string) (string, err
 	return buf.String(), nil
 }
 
-func unstructuredPath(u unstructured.Unstructured, jsonPath string) (string, bool, error) {
-	splitFunction := func(c rune) bool {
-		return c == '.'
-	}
-	statusPath := strings.FieldsFunc(jsonPath, splitFunction)
-	value, f, err := unstructured.NestedString(u.UnstructuredContent(), statusPath...)
-	if err != nil {
-		return "", false, err
-	}
-	return value, f, nil
-}
-
 func unstructuredSlicePath(u unstructured.Unstructured, jsonPath string) ([]interface{}, bool, error) {
 	splitFunction := func(c rune) bool {
 		return c == '.'

--- a/pkg/client/test-files/configuration_override.yaml
+++ b/pkg/client/test-files/configuration_override.yaml
@@ -14,7 +14,9 @@ spec:
       include: 
       - "test-namespace*"
     fields: 
-    - path: .status.phase=active
+    - path: .status.phase
+      values: 
+      - active
     required: true
     configuration:
       successThreshold: 10

--- a/pkg/client/test-files/custom_validation.yaml
+++ b/pkg/client/test-files/custom_validation.yaml
@@ -21,5 +21,7 @@ spec:
       include: 
       - "test-dog*"
     fields: 
-    - path: .status.phase=woof
+    - path: .status.phase
+      values: 
+      - woof
     required: true

--- a/pkg/client/test-files/field_validation.yaml
+++ b/pkg/client/test-files/field_validation.yaml
@@ -14,5 +14,8 @@ spec:
       include: 
       - "test-namespace*"
     fields: 
-    - path: .status.phase=active
+    - path: .status.phase
+      values:
+      - active
+      - active2
     required: true

--- a/pkg/client/test-files/field_validation.yaml
+++ b/pkg/client/test-files/field_validation.yaml
@@ -17,5 +17,4 @@ spec:
     - path: .status.phase
       values:
       - active
-      - active2
     required: true

--- a/pkg/client/test-files/field_validation_jsonpath.yaml
+++ b/pkg/client/test-files/field_validation_jsonpath.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1alpha1
 kind: ClusterValidator
 metadata:
-  name: scope-validation
+  name: field-validation
 spec:
   configuration:
     successThreshold: 3
@@ -13,15 +13,13 @@ spec:
     names:
       include: 
       - test-pod*
-      exclude: 
-      - test-pod-2
     namespaces:
       include:
       - test-namespace*
-      exclude:
-      - test-namespace-3
     fields: 
-    - path: .status.phase
+    - path: "{.status.containerStatuses[*].state.running.startedAt}"
+    - path: "{.status.phase}"
       values:
       - running
+      - succeeded
     required: true

--- a/pkg/client/validator.go
+++ b/pkg/client/validator.go
@@ -246,22 +246,17 @@ func (v *Validator) validateFields(r v1alpha1.ClusterResource, resources []unstr
 	for _, field := range r.Fields {
 
 		var (
-			JSONPath   = field.JSONPath()
-			pathValues = field.Values()
+			JSONPath   = field.GetPath()
+			pathValues = field.GetValues()
 			result     = NewFieldValidationResult(field.Path)
 		)
 
 		for _, resource := range resources {
 			var name = namespacedName(resource)
 
-			val, ok, err := unstructuredPath(resource, JSONPath)
+			val, err := getJsonPathValue(resource, JSONPath)
 			if err != nil {
 				reason := fmt.Sprintf("field '%v' has type mismatch: %v", field.Path, err)
-				result.ResourceErrors[reason] = append(result.ResourceErrors[reason], name)
-			}
-
-			if !ok {
-				reason := fmt.Sprintf("could not find JSONPath '%v' in resources", field.Path)
 				result.ResourceErrors[reason] = append(result.ResourceErrors[reason], name)
 			}
 


### PR DESCRIPTION
Signed-off-by: Eytan Avisror <eytan_avisror@intuit.com>

Fixes #7 

This refactors the field validation implementation so that values are now separate, and also support JSONPath format from client-go.

